### PR TITLE
Remove lag from hovering search options

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -107,6 +107,10 @@
   cursor:pointer;
 }
 
+.optionElement:hover {
+  background-color: #f5f5f5;
+}
+
 .optionElement p {
   display:inline-block;
 }

--- a/js/search.jsx
+++ b/js/search.jsx
@@ -51,6 +51,7 @@ let Sok = React.createClass({
                 handleHint={this.handleHint}
                 onFocus={this.handleFocus}
                 autoFocus={this.props.data.search.inputValue ? true : false}
+                hoverSelect={false}
                 ref="typeahead"
               />
               {this.renderIndicator()}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "material-ui": "^0.10.0",
     "object-assign": "^3.0.0",
     "react-tap-event-plugin": "^0.1.7",
-    "react-typeahead-component": "^0.6.0"
+    "react-typeahead-component": "^0.7.0"
   }
 }


### PR DESCRIPTION
Implement latest version of Typeahead to remove event calls on hover,
replacing with css.
